### PR TITLE
More CLI options 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,22 @@ or
 
 Use `-h` to list all Options
 
-* `-c` Count - Number of words per suggestion. Default - `4`
-* `-d` Delimiter - String delimiter between words. Default - `\space`
+* `-c` `--count` Count - Number of words per suggestion. Default - `4`
+* `-d` `--delimiter` Delimiter - String delimiter between words. Default - `\space`
+* `-s` `--suggestions` Number of Suggestions. Default - `1`
+* `-l` `--lte` Minimum number of Characters in a word. Default - `4`
+* `-g` `--gte` Maximum number of Characters in a word. Default - `7`
+* `-h` `--help`
 
 ## What's working?
 
 Generates XKCD Style passwords.
 
-You can configure word count, add delimiters as of now.
+You can configure word count, add delimiters as of now, specify minumum/maximum characters per word and the number of suggestions.
 
 ## To-Do
 
-- [ ] Use arguments to give different outputs like min/max word length, number of suggestions etc...
+- [x] Use arguments to give different outputs like min/max word length, number of suggestions etc...
 - [ ] acrostic outputs
 - [ ] calculate and show entropy of the passwords
 

--- a/src/xkcd_936/core.clj
+++ b/src/xkcd_936/core.clj
@@ -18,11 +18,11 @@
      :default 4
      :parse-fn #(Integer/parseInt %)
      :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]
-    ["-min" "--minimum Minimum" "Minimum number of Characters"
+    ["-l" "--lte Minimum" "Less than or Equal to x number of Characters"
      :default 4
      :parse-fn #(Integer/parseInt %)
      :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]
-    ["-max" "--maximum Maximum" "Maximum number of Characters"
+    ["-g" "--gte Maximum" "Greater than or Equal to x number of Characters"
      :default 7
      :parse-fn #(Integer/parseInt %)
      :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]
@@ -49,7 +49,7 @@
 (defn randomWordFromOptions [words options]
   (let [randomWord (string/join \space (take 1 (secureShuffle words)))]
     (cond
-      (and (>= (count randomWord) (:minimum options)) (<= (count randomWord) (:maximum options))) randomWord
+      (and (>= (count randomWord) (:lte options)) (<= (count randomWord) (:gte options))) randomWord
       :else (randomWordFromOptions words options)
       )))
 

--- a/src/xkcd_936/core.clj
+++ b/src/xkcd_936/core.clj
@@ -46,8 +46,20 @@
 
 (def url "https://raw.githubusercontent.com/jchristopherinc/xkcd-936/master/words.txt")
 
+(defn randomWordFromOptions [words options]
+  (let [randomWord (string/join \space (take 1 (secureShuffle words)))]
+    (cond
+      (and (>= (count randomWord) (:minimum options)) (<= (count randomWord) (:maximum options))) randomWord
+      :else (randomWordFromOptions words options)
+      )))
+
 (defn password [words options]
-  (string/join (:delimiter options) (take (:count options) (secureShuffle words))))
+  (let [al (ArrayList.)]
+    (loop [i 0]
+      (when (< i (:count options))
+        (.add al (randomWordFromOptions words options))
+        (recur (inc i))))
+  (string/join (:delimiter options) al)))
 
 (if-not (.exists (io/file fileName))
   (spit fileName (slurp url)))
@@ -57,5 +69,8 @@
     (cond
       (:help options) (exit 0 summary)
       errors (exit 1 errors))
-    (println (password (lines fileName) options))
-    ))
+    (let [wordList (lines fileName)]
+      (loop [i 0]
+        (when (< i (:suggestions options))
+          (println (password wordList options))
+          (recur (inc i)))))))


### PR DESCRIPTION
Supporting overall list of CLI options
```
  -s, --suggestions Suggestions  1  Number of Suggestions
  -d, --delimiter Delimiter         Delimiter
  -c, --count Count              4  Number of words per suggestion
  -l, --lte Minimum              4  Less than or Equal to x number of Characters
  -g, --gte Maximum              7  Greater than or Equal to x number of Characters
  -h, --help
```
